### PR TITLE
Provide getter for isLogStartupInfo

### DIFF
--- a/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
+++ b/spring-boot/src/main/java/org/springframework/boot/SpringApplication.java
@@ -996,6 +996,10 @@ public class SpringApplication {
 	public void setLogStartupInfo(boolean logStartupInfo) {
 		this.logStartupInfo = logStartupInfo;
 	}
+	
+	public boolean isLogStartupInfo(){
+		return this.logStartupInfo;
+	}
 
 	/**
 	 * Sets if a {@link CommandLinePropertySource} should be added to the application


### PR DESCRIPTION
Working through an issue to stop Spring Cloud's Bootstrap Context from logging two `ContextPrepared` events.

I'll provide a link to that issue once it's opened, but the long and short of it is they create a new SpringApplication and don't have access to `SpringApplication#logStartupInfo` so they can't carry that property over.

This is pretty minimal / low impact. Happy to provide JavaDoc / Unit Tests if needed, but I think it's trivial enough that shouldn't require much. 
